### PR TITLE
Ensure that Travis-CI only builds 'master' branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,7 @@ node_js:
   - "node"
   - "7"
   - "6"
+
+branches:
+  only:
+    - master


### PR DESCRIPTION
In preparation for enabling GitHub's automated security fix system, this patch
changes the Travis-CI configuration so that only pushes to the 'master' branch
will trigger builds (along with Pull Requests from any location).

The automated security fix system will create PRs in this repo and send PRs from
them, and without this configuration change Travis-CI will build both the branch
and the PR, which is a waste of time and resources.

Signed-off-by: Kevin P. Fleming <kpfleming@bloomberg.net>